### PR TITLE
Build binary ci

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -1,0 +1,36 @@
+name: binaries
+
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    tags:
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - run: echo "IMAGE_TAG=dev" >> $GITHUB_ENV
+      if: ${{ github.ref_name }} == 'main'
+    - run: echo "IMAGE_TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      if: startsWith(github.ref, 'refs/tags/v')
+    
+    - run: apt-get update -y && apt-get install -y rsync
+    - name: build
+      id: build
+      run: ./avalanchego/scripts/build.sh
+
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist-bin
+        path: |
+          avalanchego/build

--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -26,7 +26,9 @@ jobs:
     - run: sudo apt-get update -y && sudo apt-get install -y rsync
     - name: build
       id: build
-      run: ./avalanchego/scripts/build.sh
+      run: |
+        cd avalanchego
+        ./scripts/build.sh
 
     - name: Archive production artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -7,6 +7,8 @@ on:
     branches:
     tags:
 
+env:
+  go_version: 1.18.5
 
 jobs:
   build:
@@ -17,6 +19,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ env.go_version }}
+
 
     - run: echo "IMAGE_TAG=dev" >> $GITHUB_ENV
       if: ${{ github.ref_name }} == 'main'

--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -23,7 +23,7 @@ jobs:
     - run: echo "IMAGE_TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
       if: startsWith(github.ref, 'refs/tags/v')
     
-    - run: apt-get update -y && apt-get install -y rsync
+    - run: sudo apt-get update -y && sudo apt-get install -y rsync
     - name: build
       id: build
       run: ./avalanchego/scripts/build.sh


### PR DESCRIPTION
Introduce a workflow that builds avalanchego binaries and stores them as job artifacts