### PR TITLE
Add --bootstrap-beacon-connection-timeout env supp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ ENV HTTP_HOST=0.0.0.0 \
     AUTOCONFIGURE_PUBLIC_IP=1 \
     AUTOCONFIGURE_BOOTSTRAP=1 \
     AUTOCONFIGURE_BOOTSTRAP_ENDPOINT=https://coston2.flare.network/ext/info \
-    EXTRA_ARGUMENTS=""
+    EXTRA_ARGUMENTS="" \
+    BOOTSTRAP_BEACON_CONNECTION_TIMEOUT="1m"
 
 RUN apt-get update -y && \
     apt-get install -y curl jq

--- a/README-docker.md
+++ b/README-docker.md
@@ -53,7 +53,8 @@ These are the environment variables you can edit and their default values:
 | `NETWORK_ID` | `costwo` | The network id. The common ids are `flare \| costwo` |
 | `AUTOCONFIGURE_PUBLIC_IP` | `0` | Set to `1` to autoconfigure `PUBLIC_IP`, skipped if PUBLIC_IP is set |
 | `AUTOCONFIGURE_BOOTSTRAP` | `0` | Set to `1` to autoconfigure `BOOTSTRAP_IPS` and `BOOTSTRAP_IDS` |
-| `AUTOCONFIGURE_BOOTSTRAP_ENDPOINT` | `https://coston2.flare.network/ext/info` <b>or</b> `https://flare.flare.network/ext/info` | Endpoint used for [bootstrapping](https://docs.avax.network/nodes/maintain/avalanchego-config-flags#bootstrapping) when `AUTOCONFIGURE_BOOTSTRAP` is enabled. For the `flare` network id, this has to be set to `https://flare.flare.network/ext/info` |
+| `AUTOCONFIGURE_BOOTSTRAP_ENDPOINT` | `https://coston2.flare.network/ext/info` or<br> `https://flare.flare.network/ext/info` | Endpoint used for [bootstrapping](https://docs.avax.network/nodes/maintain/avalanchego-config-flags#bootstrapping) when `AUTOCONFIGURE_BOOTSTRAP` is enabled. For the `flare` network id, this has to be set to `https://flare.flare.network/ext/info` |
+| `BOOTSTRAP_BEACON_CONNECTION_TIMEOUT` | `1m` | Set the duration value (eg. `45s` / `5m` / `1h`) for [--bootstrap-beacon-connection-timeout](https://docs.avax.network/nodes/maintain/avalanchego-config-flags#--bootstrap-beacon-connection-timeout-duration) AvalancheGo flag. | 
 | `EXTRA_ARGUMENTS` | | Extra arguments passed to flare binary |
 
 

--- a/README-docker.md
+++ b/README-docker.md
@@ -49,11 +49,11 @@ These are the environment variables you can edit and their default values:
 | `BOOTSTRAP_IDS` | _(empty)_ | A list of bootstrap server ids; ref [--bootstrap-ids-string](https://docs.avax.network/nodes/maintain/avalanchego-config-flags#--bootstrap-ids-string) |
 | `CHAIN_CONFIG_DIR` | `/app/conf` | Configuration directory |
 | `LOG_DIR` | `/app/logs` | Logging directory |
-| `LOG_LEVEL` | `info` | Logging level |
+| `LOG_LEVEL` | `info` | Logging level set with AvalancheGo flag [`--log-level`](https://docs.avax.network/nodes/maintain/avalanchego-config-flags#--log-level-string-verbo-debug-trace-info-warn-error-fatal-off). |
 | `NETWORK_ID` | `costwo` | The network id. The common ids are `flare \| costwo` |
 | `AUTOCONFIGURE_PUBLIC_IP` | `0` | Set to `1` to autoconfigure `PUBLIC_IP`, skipped if PUBLIC_IP is set |
 | `AUTOCONFIGURE_BOOTSTRAP` | `0` | Set to `1` to autoconfigure `BOOTSTRAP_IPS` and `BOOTSTRAP_IDS` |
-| `AUTOCONFIGURE_BOOTSTRAP_ENDPOINT` | `https://coston2.flare.network/ext/info` or<br> `https://flare.flare.network/ext/info` | Endpoint used for [bootstrapping](https://docs.avax.network/nodes/maintain/avalanchego-config-flags#bootstrapping) when `AUTOCONFIGURE_BOOTSTRAP` is enabled. For the `flare` network id, this has to be set to `https://flare.flare.network/ext/info` |
+| `AUTOCONFIGURE_BOOTSTRAP_ENDPOINT` | `https://coston2.flare.network/ext/info` | Endpoint used for [bootstrapping](https://docs.avax.network/nodes/maintain/avalanchego-config-flags#bootstrapping) when `AUTOCONFIGURE_BOOTSTRAP` is enabled. Possible values are `https://coston2.flare.network/ext/info` or `https://flare.flare.network/ext/info`. |
 | `BOOTSTRAP_BEACON_CONNECTION_TIMEOUT` | `1m` | Set the duration value (eg. `45s` / `5m` / `1h`) for [--bootstrap-beacon-connection-timeout](https://docs.avax.network/nodes/maintain/avalanchego-config-flags#--bootstrap-beacon-connection-timeout-duration) AvalancheGo flag. | 
 | `EXTRA_ARGUMENTS` | | Extra arguments passed to flare binary |
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,6 +37,7 @@ fi
 	--db-type=$DB_TYPE \
 	--bootstrap-ips=$BOOTSTRAP_IPS \
 	--bootstrap-ids=$BOOTSTRAP_IDS \
+	--bootstrap-beacon-connection-timeout=$BOOTSTRAP_BEACON_CONNECTION_TIMEOUT \
 	--chain-config-dir=$CHAIN_CONFIG_DIR \
 	--log-dir=$LOG_DIR \
 	--log-level=$LOG_LEVEL \


### PR DESCRIPTION
- Adds support for defining the [--bootstrap-beacon-connection-timeout-duration](https://docs.avax.network/nodes/maintain/avalanchego-config-flags#--bootstrap-beacon-connection-timeout-duration) flag value via env vars
- iproves docker docs a bit