### PR TITLE
Fix some outdated explanations in docker README

### DIFF
--- a/README-docker.md
+++ b/README-docker.md
@@ -51,8 +51,8 @@ These are the environment variables you can edit and their default values:
 | `LOG_DIR` | `/app/logs` | Logging directory |
 | `LOG_LEVEL` | `info` | Logging level set with AvalancheGo flag [`--log-level`](https://docs.avax.network/nodes/maintain/avalanchego-config-flags#--log-level-string-verbo-debug-trace-info-warn-error-fatal-off). |
 | `NETWORK_ID` | `costwo` | The network id. The common ids are `flare \| costwo` |
-| `AUTOCONFIGURE_PUBLIC_IP` | `0` | Set to `1` to autoconfigure `PUBLIC_IP`, skipped if PUBLIC_IP is set |
-| `AUTOCONFIGURE_BOOTSTRAP` | `0` | Set to `1` to autoconfigure `BOOTSTRAP_IPS` and `BOOTSTRAP_IDS` |
+| `AUTOCONFIGURE_PUBLIC_IP` | `1` | Set to `0` to manually configure `PUBLIC_IP`, skipped if PUBLIC_IP is set |
+| `AUTOCONFIGURE_BOOTSTRAP` | `1` | Set to `0` to manually configure `BOOTSTRAP_IPS` and `BOOTSTRAP_IDS` |
 | `AUTOCONFIGURE_BOOTSTRAP_ENDPOINT` | `https://coston2.flare.network/ext/info` | Endpoint used for [bootstrapping](https://docs.avax.network/nodes/maintain/avalanchego-config-flags#bootstrapping) when `AUTOCONFIGURE_BOOTSTRAP` is enabled. Possible values are `https://coston2.flare.network/ext/info` or `https://flare.flare.network/ext/info`. |
 | `BOOTSTRAP_BEACON_CONNECTION_TIMEOUT` | `1m` | Set the duration value (eg. `45s` / `5m` / `1h`) for [--bootstrap-beacon-connection-timeout](https://docs.avax.network/nodes/maintain/avalanchego-config-flags#--bootstrap-beacon-connection-timeout-duration) AvalancheGo flag. | 
 | `EXTRA_ARGUMENTS` | | Extra arguments passed to flare binary |
@@ -72,13 +72,13 @@ The external API configuration is set to only respond to API calls so it offload
   "coreth-admin-api-enabled": false,
   "coreth-admin-api-dir": "",
   "eth-apis": [
-    "public-eth",
-    "public-eth-filter",
+    "eth",
+    "eth-filter",
     "net",
     "web3",
-    "internal-public-eth",
-    "internal-public-blockchain",
-    "internal-public-transaction-pool"
+    "internal-eth",
+    "internal-blockchain",
+    "internal-transaction"
   ],
 }
 ```
@@ -93,22 +93,20 @@ Similarly to the external API configuration, this one also responds to API calls
   "coreth-admin-api-enabled": false,
   "coreth-admin-api-dir": "",
   "eth-apis": [
-    "public-eth",
-    "public-eth-filter",
-    "private-admin",
-    "public-debug",
-    "private-debug",
+    "eth",
+    "eth-filter",
+    "admin",
+    "debug",
     "net",
     "debug-tracer",
     "web3",
-    "internal-public-eth",
-    "internal-public-blockchain",
-    "internal-public-transaction-pool",
-    "internal-public-tx-pool",
-    "internal-public-debug",
-    "internal-private-debug",
-    "internal-public-account",
-    "internal-private-personal"
+    "internal-eth",
+    "internal-blockchain",
+    "internal-transaction",
+    "internal-tx-pool",
+    "internal-debug",
+    "internal-account",
+    "internal-personal"
   ],
 }
 ```


### PR DESCRIPTION
Hello. I'm dmjo who loves Flare.
I really appreciate for developing such a nice node system. 

I'm operating some of Flare observers now with dockerization
and found some mismatch between real operation and the docker README.


## What is the problem?
1.  Mismatch between README and Dockerfile
    - The [README-docker.md](https://github.com/flare-foundation/go-flare/blob/main/README-docker.md) file reads that both `AUTOCONFIGURE_PUBLIC_IP` and `AUTOCONFIGURE_BOOTSTRAP` is set to **'0'** as default.
    -  [Dockerfile](https://github.com/flare-foundation/go-flare/blob/cb5ff5b717b9f103e517b97739a2b9b3dbcf28f1/Dockerfile#L20C1-L37C45), however, configures them as **'1'** when initializing.
    - Below is part of current Dockerfile which set them to '1'
```

ENV HTTP_HOST=0.0.0.0 \
    HTTP_PORT=9650 \
    STAKING_PORT=9651 \
    PUBLIC_IP= \
    DB_DIR=/app/db \
    DB_TYPE=leveldb \
    BOOTSTRAP_IPS= \
    BOOTSTRAP_IDS= \
    CHAIN_CONFIG_DIR=/app/conf \
    LOG_DIR=/app/logs \
    LOG_LEVEL=info \
    NETWORK_ID=costwo \
    AUTOCONFIGURE_PUBLIC_IP=1 \
    AUTOCONFIGURE_BOOTSTRAP=1 \
    AUTOCONFIGURE_BOOTSTRAP_ENDPOINT=https://coston2.flare.network/ext/info \
    EXTRA_ARGUMENTS="" \
    BOOTSTRAP_BEACON_CONNECTION_TIMEOUT="1m"
```
  - I think this should be fixed in the way like this PR or the other way (set to '0' in Dockerfile).
  
2. Some explanations in configuration are outdated. 
    - Coreth `v0.8.14` **deprecated** some of the configuration flags for eth_apis **containing `public-` and `private-`**.
    - AFAIK, the latest version of `go-flare` is now using **Coreth `v0.8.16`** so the configurations should be changed. 
    - You can find the information in [the link](https://docs.avax.network/nodes/configure/chain-config-flags#enabling-evm-apis) and the picture I attached below
    
<img width="879" alt="image" src="https://github.com/flare-foundation/go-flare/assets/15776559/2edb4ca1-e5c1-431d-9d0f-7cbb4377d1c8">



