### PR TITLE
Add support for fallback bootstrap endpoints

### DIFF
--- a/README-docker.md
+++ b/README-docker.md
@@ -54,6 +54,7 @@ These are the environment variables you can edit and their default values:
 | `AUTOCONFIGURE_PUBLIC_IP` | `0` | Set to `1` to autoconfigure `PUBLIC_IP`, skipped if PUBLIC_IP is set |
 | `AUTOCONFIGURE_BOOTSTRAP` | `0` | Set to `1` to autoconfigure `BOOTSTRAP_IPS` and `BOOTSTRAP_IDS` |
 | `AUTOCONFIGURE_BOOTSTRAP_ENDPOINT` | `https://coston2.flare.network/ext/info` | Endpoint used for [bootstrapping](https://docs.avax.network/nodes/maintain/avalanchego-config-flags#bootstrapping) when `AUTOCONFIGURE_BOOTSTRAP` is enabled. Possible values are `https://coston2.flare.network/ext/info` or `https://flare.flare.network/ext/info`. |
+| `AUTOCONFIGURE_FALLBACK_ENDPOINTS` | _(empty)_ | Comma-divided fallback bootstrap endpoints, used if `AUTOCONFIGURE_BOOTSTRAP_ENDPOINT` is not valid (not whitelisted / unreachable / etc), tested from first-to-last until one is valid |
 | `BOOTSTRAP_BEACON_CONNECTION_TIMEOUT` | `1m` | Set the duration value (eg. `45s` / `5m` / `1h`) for [--bootstrap-beacon-connection-timeout](https://docs.avax.network/nodes/maintain/avalanchego-config-flags#--bootstrap-beacon-connection-timeout-duration) AvalancheGo flag. | 
 | `EXTRA_ARGUMENTS` | | Extra arguments passed to flare binary |
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,7 @@ then
             __BOOTSTRAP_ENDPOINT="$__ENDPOINT"
             break
         else
-			echo "    Failed! The endpoint is unreachable or your IP is not whitelisted."
+			echo "    Failed! The endpoint is unreachable."
             continue
         fi
     done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,26 +7,49 @@ then
 	if [ "$PUBLIC_IP" = "" ];
 	then
 		echo "Autoconfiguring public IP"
-		PUBLIC_IP=$(curl https://api.ipify.org/)
+		PUBLIC_IP=$(curl -s https://api.ipify.org/)
+		echo "  Got public address '${PUBLIC_IP}'" 
 	else
 		echo "/!\\ AUTOCONFIGURE_PUBLIC_IP is enabled, but PUBLIC_IP is already set to '$PUBLIC_IP'! Skipping autoconfigure and using current PUBLIC_IP value!"
 	fi
 fi
 
-# Check if we can connect to the bootstrap endpoint (whitelisting)
-BOOTSTRAP_STATUS=$(curl -m 10 -s -w %{http_code} -X POST --data '{ "jsonrpc":"2.0", "id":1, "method":"info.getNodeIP" }' -H 'content-type:application/json;' "$AUTOCONFIGURE_BOOTSTRAP_ENDPOINT" -o /dev/null)
-if [ "$BOOTSTRAP_STATUS" != "200" ]; then
-	echo "Could not connect to bootstrap endpoint. Is your IP whitelisted?"
-	exit 1
-fi
-
 if [ "$AUTOCONFIGURE_BOOTSTRAP" = "1" ];
 then
+
+
+    __BOOTSTRAP_ENDPOINTS=("${AUTOCONFIGURE_BOOTSTRAP_ENDPOINT}" ${AUTOCONFIGURE_FALLBACK_ENDPOINTS//,/ })
+
+	echo "Trying provided bootstrap endpoints"
+	for __ENDPOINT in "${__BOOTSTRAP_ENDPOINTS[@]}"; do
+        echo "  Trying endpoint $__ENDPOINT"
+
+        RESPONSE_CODE=$(curl -X POST -m 5 -s -o /dev/null -w '%{http_code}' "$__ENDPOINT" -H 'Content-Type: application/json' --data '{ "jsonrpc":"2.0", "id":1, "method":"info.getNodeIP" }' || true)
+        if [ "$RESPONSE_CODE" = "200" ]; then
+            __BOOTSTRAP_ENDPOINT="$__ENDPOINT"
+            break
+        else
+			echo "    Failed! The endpoint is unreachable or your IP is not whitelisted."
+            continue
+        fi
+    done
+
+	if [ -z "$__BOOTSTRAP_ENDPOINT" ]; then
+        echo "  None of provided bootstrap endpoints worked!"
+        exit 1
+    fi
+
+
 	echo "Autoconfiguring bootstrap IPs and IDs"
 
-	BOOTSTRAP_IPS=$(curl -m 10 -sX POST --data '{ "jsonrpc":"2.0", "id":1, "method":"info.getNodeIP" }' -H 'content-type:application/json;' "$AUTOCONFIGURE_BOOTSTRAP_ENDPOINT" | jq -r ".result.ip")
-	BOOTSTRAP_IDS=$(curl -m 10 -sX POST --data '{ "jsonrpc":"2.0", "id":1, "method":"info.getNodeID" }' -H 'content-type:application/json;' "$AUTOCONFIGURE_BOOTSTRAP_ENDPOINT" | jq -r ".result.nodeID")
+	BOOTSTRAP_IPS=$(curl -m 10 -sX POST --data '{ "jsonrpc":"2.0", "id":1, "method":"info.getNodeIP" }' -H 'content-type:application/json;' "$__BOOTSTRAP_ENDPOINT" | jq -r ".result.ip")
+	BOOTSTRAP_IDS=$(curl -m 10 -sX POST --data '{ "jsonrpc":"2.0", "id":1, "method":"info.getNodeID" }' -H 'content-type:application/json;' "$__BOOTSTRAP_ENDPOINT" | jq -r ".result.nodeID")
+
+	echo "  Got bootstrap ips: '${BOOTSTRAP_IPS}'"
+	echo "  Got bootstrap ids: '${BOOTSTRAP_IDS}'"
 fi
+
+exit 0
 
 /app/build/avalanchego \
 	--http-host=$HTTP_HOST \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,8 +49,6 @@ then
 	echo "  Got bootstrap ids: '${BOOTSTRAP_IDS}'"
 fi
 
-exit 0
-
 /app/build/avalanchego \
 	--http-host=$HTTP_HOST \
 	--http-port=$HTTP_PORT \


### PR DESCRIPTION
Adds `AUTOCONFIGURE_FALLBACK_ENDPOINTS` environment variable handling to entrypoint script, testing provided fallback endpoints until one is valid