### PR TITLE
patch(devops): use ubuntu@24.10 instead of sha-locked image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app/avalanchego/
 
 RUN /app/avalanchego/scripts/build.sh
 
-FROM ubuntu@sha256:0eb0f877e1c869a300c442c41120e778db7161419244ee5cbc6fa5f134e74736
+FROM ubuntu@24.10
 
 WORKDIR /app
 


### PR DESCRIPTION
In order to support multi-platform builds.
Using a digest-locked image makes the built image only support the architecture that the base image (digest) supports. Meanwhile if we use the "tagged" image we can have multiplatform images.