### PR TITLE
Feat: Update the actions and add cosign for signing images

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -50,24 +50,20 @@ jobs:
     - name: Install Cosign
       uses: sigstore/cosign-installer@v3.8.1
 
-    - name: sign container image
+    - name: Sign container image
       shell: bash
       env:
-        COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
-        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        COSIGN_EXPERIMENTAL: 1
       run: |
-        cosign sign --yes --key env://COSIGN_KEY "ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}"
+        cosign sign --yes "ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}"
 
-        cosign sign --yes --key env://COSIGN_KEY "${{ secrets.DOCKER_HUB_REPO }}:${{ env.IMAGE_TAG }}"
+        cosign sign --yes "${{ secrets.DOCKER_HUB_REPO }}:${{ env.IMAGE_TAG }}"
     
     - name: Verify image signatures
       shell: bash
       env: 
-        COSIGN_PUBLIC_KEY_CONTENT: ${{ secrets.COSIGN_PUBLIC_KEY }}
+        COSIGN_EXPERIMENTAL: 1
       run: |
-        echo "${COSIGN_PUBLIC_KEY_CONTENT}" > ./cosign.pub
-        cosign verify --key ./cosign.pub "ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}"
+        cosign verify "ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}"
+        cosign verify "${{ secrets.DOCKER_HUB_REPO }}:${{ env.IMAGE_TAG }}"
 
-        cosign verify --key ./cosign.pub "${{ secrets.DOCKER_HUB_REPO }}:${{ env.IMAGE_TAG }}"
-
-        rm -f ./cosign.pub

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -12,12 +12,13 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: docker/setup-qemu-action@v1
-    - uses: docker/setup-buildx-action@v1
+    - uses: docker/setup-qemu-action@v3
+    - uses: docker/setup-buildx-action@v3
 
     - run: echo "IMAGE_TAG=dev" >> $GITHUB_ENV
       if: github.ref_name == 'main'
@@ -25,14 +26,14 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/v')
 
     - name: Login to ghcr.io
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Login to docker.io
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_HUB_UID }}
         password: ${{ secrets.DOCKER_HUB_PAT }}
@@ -45,3 +46,28 @@ jobs:
           --tag ${{ secrets.DOCKER_HUB_REPO }}:${{ env.IMAGE_TAG }} \
           --file ./Dockerfile \
           --output type=image,push=true .
+
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@v3.8.1
+
+    - name: sign container image
+      shell: bash
+      env:
+        COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+      run: |
+        cosign sign --yes --key env://COSIGN_KEY "ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}"
+
+        cosign sign --yes --key env://COSIGN_KEY "${{ secrets.DOCKER_HUB_REPO }}:${{ env.IMAGE_TAG }}"
+    
+    - name: Verify image signatures
+      shell: bash
+      env: 
+        COSIGN_PUBLIC_KEY_CONTENT: ${{ secrets.COSIGN_PUBLIC_KEY }}
+      run: |
+        echo "${COSIGN_PUBLIC_KEY_CONTENT}" > ./cosign.pub
+        cosign verify --key ./cosign.pub "ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}"
+
+        cosign verify --key ./cosign.pub "${{ secrets.DOCKER_HUB_REPO }}:${{ env.IMAGE_TAG }}"
+
+        rm -f ./cosign.pub


### PR DESCRIPTION
## Describe your changes

In this PR, I have updated the actions and added Cosign for signing images. I mostly followed this [demo](https://github.com/chrisns/cosign-keyless-demo). We are using keyless signing of images.

~~In the future, the private key should be added to Google Cloud KMS, and the command should be augmented to use the key from Google Cloud KMS. [Here is an example of how this is done in AWS](https://medium.com/@laur.telliskivi/container-image-signing-why-and-how-6aa4248ca617)~~