### PR TITLE
Feat:Add Cosign image signature

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -54,7 +54,13 @@ jobs:
           $TAGS \
           --file ./Dockerfile \
           --output type=image,push=true \
+          --iidfile std.digest \
           .
+
+    - name: Export standard image digest  
+      run: |
+        DIG=$(cat std.digest)
+        echo "IMAGE_DIGEST=$DIG" >> $GITHUB_ENV
 
     - name: Build distroless image
       run: |
@@ -69,4 +75,62 @@ jobs:
           $TAGS \
           --file ./Dockerfile.dless \
           --output type=image,push=true \
+          --iidfile dless.digest \
           .
+
+    - name: Export distroless image digest
+      run: |
+        DIG=$(cat dless.digest)
+        echo "DLESS_IMAGE_DIGEST=$DIG" >> $GITHUB_ENV
+
+
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@v3.8.1
+
+    - name: Sign ghcr images
+      shell: bash
+      env:
+        COSIGN_EXPERIMENTAL: 1
+      run: |
+          cosign sign --yes ghcr.io/${{ github.repository }}@${{ env.IMAGE_DIGEST }}
+          cosign sign --yes ghcr.io/${{ github.repository }}@${{ env.DLESS_IMAGE_DIGEST }}
+    
+    - name: Sign docker hub images
+      if: ${{ env.USE_DOCKER_HUB == 'true' }}
+      shell: bash
+      env:
+        COSIGN_EXPERIMENTAL: 1
+      run: |
+          cosign sign --yes ${{ secrets.DOCKER_HUB_REPO }}@${{ env.IMAGE_DIGEST }}
+          cosign sign --yes ${{ secrets.DOCKER_HUB_REPO }}@${{ env.DLESS_IMAGE_DIGEST }}
+
+    - name: Verify ghcr image signatures
+      shell: bash
+      env:
+        COSIGN_EXPERIMENTAL: 1
+      run: |
+        cosign verify \
+          --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/build-container.yml@${{ github.ref }} \
+          --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+          "ghcr.io/${{ github.repository }}@${{ env.IMAGE_DIGEST }}"
+
+        cosign verify \
+          --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/build-container.yml@${{ github.ref }} \
+          --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+          "ghcr.io/${{ github.repository }}@${{ env.DLESS_IMAGE_DIGEST }}"
+    
+    - name: Verify docker hub image signatures
+      if: ${{ env.USE_DOCKER_HUB == 'true' }}
+      shell: bash
+      env:
+        COSIGN_EXPERIMENTAL: 1
+      run: |
+        cosign verify \
+          --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/build-container.yml@${{ github.ref }} \
+          --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+          "${{ secrets.DOCKER_HUB_REPO }}@${{ env.IMAGE_DIGEST }}"
+
+        cosign verify \
+          --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/build-container.yml@${{ github.ref }} \
+          --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+          "${{ secrets.DOCKER_HUB_REPO }}@${{ env.DLESS_IMAGE_DIGEST }}"       


### PR DESCRIPTION
In this PR, I’m adding back the Cosign signing step, as it broke before when we used the wrong tag to sign the distroless image. I’m also fixing it by using the image digest to sign the images, which will prevent a race condition.