### PR TITLE
Chore: add sbom, provenance and latest tag

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -13,6 +13,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     env:
       USE_DOCKER_HUB: false
     steps:
@@ -187,7 +188,7 @@ jobs:
           --format '{{ json (index .SBOM "linux/amd64").SPDX }}' > std-sbom.spdx.json
 
     - name: Attest standard image SBOM
-      uses: actions/attest-sbom@v2
+      uses: actions/attest-sbom@v4
       with:
         subject-name: ghcr.io/${{ github.repository }}
         subject-digest: ${{ env.IMAGE_DIGEST }}
@@ -201,7 +202,7 @@ jobs:
           --format '{{ json (index .SBOM "linux/amd64").SPDX }}' > dless-sbom.spdx.json
 
     - name: Attest distroless image SBOM
-      uses: actions/attest-sbom@v2
+      uses: actions/attest-sbom@v4
       with:
         subject-name: ghcr.io/${{ github.repository }}
         subject-digest: ${{ env.DLESS_IMAGE_DIGEST }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -32,7 +32,8 @@ jobs:
     - name: Detect stable release
       if: startsWith(github.ref, 'refs/tags/v')
       run: |
-        if [[ ! "${GITHUB_REF##*/}" =~ -(rc|alpha|beta|pre) ]]; then
+        RELEASE_TAG_REGEX='^([a-zA-Z0-9_-]+/)?v?(0|([1-9][0-9]*))\.(0|([1-9][0-9]*))\.(0|([1-9][0-9]*))$'
+        if [[ "${GITHUB_REF##*/}" =~ $RELEASE_TAG_REGEX ]]; then
           echo "IS_STABLE=true" >> $GITHUB_ENV
         fi
 

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -14,7 +14,7 @@ jobs:
       packages: write
       id-token: write
     env:
-      USE_DOCKER_HUB: true
+      USE_DOCKER_HUB: false
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -28,6 +28,13 @@ jobs:
     - run: echo "IMAGE_TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
       if: startsWith(github.ref, 'refs/tags/v')
 
+    - name: Detect stable release
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: |
+        if [[ ! "${GITHUB_REF##*/}" =~ -(rc|alpha|beta|pre) ]]; then
+          echo "IS_STABLE=true" >> $GITHUB_ENV
+        fi
+
     - name: Login to ghcr.io
       uses: docker/login-action@v3
       with:
@@ -51,9 +58,19 @@ jobs:
         if [ "${USE_DOCKER_HUB}" = "true" ]; then
           TAGS="$TAGS --tag ${{ secrets.DOCKER_HUB_REPO }}:${{ env.IMAGE_TAG }}"
         fi
+      
+        # Add latest tag if this is a stable release
+        if [ "${IS_STABLE}" = "true" ]; then
+          TAGS="$TAGS --tag ghcr.io/${{ github.repository }}:latest"
+          if [ "${USE_DOCKER_HUB}" = "true" ]; then
+            TAGS="$TAGS --tag ${{ secrets.DOCKER_HUB_REPO }}:latest"
+          fi
+        fi
 
         docker buildx build \
           --platform linux/amd64,linux/arm64 \
+          --provenance=mode=max \
+          --sbom=true \
           $TAGS \
           --file ./Dockerfile \
           --output type=image,push=true \
@@ -70,13 +87,23 @@ jobs:
         USE_DOCKER_HUB: ${{ env.USE_DOCKER_HUB }}
       run: |
         TAGS="--tag ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}-dless"
-    
+
         if [ "${USE_DOCKER_HUB}" = "true" ]; then
           TAGS="$TAGS --tag ${{ secrets.DOCKER_HUB_REPO }}:${{ env.IMAGE_TAG }}-dless"
+        fi
+      
+        # Add latest tag if this is a stable release
+        if [ "${IS_STABLE}" = "true" ]; then
+          TAGS="$TAGS --tag ghcr.io/${{ github.repository }}:latest-dless"
+          if [ "${USE_DOCKER_HUB}" = "true" ]; then
+            TAGS="$TAGS --tag ${{ secrets.DOCKER_HUB_REPO }}:latest-dless"
+          fi
         fi
 
         docker buildx build \
           --platform linux/amd64,linux/arm64 \
+          --provenance=mode=max \
+          --sbom=true \
           $TAGS \
           --file ./Dockerfile.dless \
           --output type=image,push=true \
@@ -137,4 +164,46 @@ jobs:
         cosign verify \
           --certificate-identity=https://github.com/${{ github.repository }}/.github/workflows/build-container.yml@${{ github.ref }} \
           --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-          "${{ secrets.DOCKER_HUB_REPO }}@${{ env.DLESS_IMAGE_DIGEST }}"       
+          "${{ secrets.DOCKER_HUB_REPO }}@${{ env.DLESS_IMAGE_DIGEST }}"
+
+    - name: Attest standard image
+      uses: actions/attest-build-provenance@v4
+      with:
+        subject-name: ghcr.io/${{ github.repository }}
+        subject-digest: ${{ env.IMAGE_DIGEST }}
+        push-to-registry: true
+
+    - name: Attest distroless image
+      uses: actions/attest-build-provenance@v4
+      with:
+        subject-name: ghcr.io/${{ github.repository }}
+        subject-digest: ${{ env.DLESS_IMAGE_DIGEST }}
+        push-to-registry: true
+
+    - name: Extract standard image SBOM
+      run: |
+        docker buildx imagetools inspect \
+          ghcr.io/${{ github.repository }}@${{ env.IMAGE_DIGEST }} \
+          --format '{{ json (index .SBOM "linux/amd64").SPDX }}' > std-sbom.spdx.json
+
+    - name: Attest standard image SBOM
+      uses: actions/attest-sbom@v2
+      with:
+        subject-name: ghcr.io/${{ github.repository }}
+        subject-digest: ${{ env.IMAGE_DIGEST }}
+        sbom-path: std-sbom.spdx.json
+        push-to-registry: true
+
+    - name: Extract distroless image SBOM
+      run: |
+        docker buildx imagetools inspect \
+          ghcr.io/${{ github.repository }}@${{ env.DLESS_IMAGE_DIGEST }} \
+          --format '{{ json (index .SBOM "linux/amd64").SPDX }}' > dless-sbom.spdx.json
+
+    - name: Attest distroless image SBOM
+      uses: actions/attest-sbom@v2
+      with:
+        subject-name: ghcr.io/${{ github.repository }}
+        subject-digest: ${{ env.DLESS_IMAGE_DIGEST }}
+        sbom-path: dless-sbom.spdx.json
+        push-to-registry: true

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
       attestations: write
     env:
-      USE_DOCKER_HUB: false
+      USE_DOCKER_HUB: true
     steps:
     - uses: actions/checkout@v4
       with:

--- a/README.md
+++ b/README.md
@@ -43,12 +43,14 @@ See `tests/README.md` for testing details
 
 ## Container image
 
-Public container images are hosted on [Docker HUB](https://hub.docker.com/r/flarefoundation/go-flare) and [Github Packages](https://github.com/orgs/flare-foundation/packages?repo_name=go-flare);
+Public container images are hosted on [Docker Hub](https://hub.docker.com/r/flarefoundation/go-flare) and [GitHub Packages](https://github.com/orgs/flare-foundation/packages?repo_name=go-flare):
 
 ```
 docker.io/flarefoundation/go-flare
 ghcr.io/flare-foundation/go-flare
 ```
+
+### Verify the cosign signature
 
 Images are signed using [Cosign](https://github.com/sigstore/cosign) with the GitHub OIDC provider. To verify the image, run this command:
 
@@ -64,9 +66,34 @@ cosign verify \
   docker.io/flarefoundation/go-flare:<TAG>
 ```
 
+### Inspect provenance + SBOM
+
+Both are attached to the image and inspectable with `docker buildx imagetools`:
+
+```bash
+# provenance — build origin, source repo, commit, workflow
+docker buildx imagetools inspect ghcr.io/flare-foundation/go-flare:<TAG> \
+  --format '{{ json (index .Provenance "linux/amd64") }}' | jq
+
+# SBOM — list of packages
+docker buildx imagetools inspect ghcr.io/flare-foundation/go-flare:<TAG> \
+  --format '{{ json (index .SBOM "linux/amd64").SPDX.packages }}' | jq
+```
+
+### Verify GitHub artifact attestations
+
+Requires [GitHub CLI](https://cli.github.com/) 2.49 or later:
+
+```bash
+gh attestation verify oci://ghcr.io/flare-foundation/go-flare:<TAG> --owner flare-foundation
+```
+
 ### Container builds in CI
 
-CI builds on each:
+Builds run on:
 
-- push on `main` branch, pushes image tagged as "dev"
-- creation of a tag, pushes images tagged as the tag itself
+- Push to `main` branch → pushes image tagged `dev` + `dev-dless`
+- Push of a pre-release tag (`v*-rc.*`, `v*-alpha.*`, etc.) → pushes tagged image + `-dless` variant
+- Push of a stable tag (e.g. `v1.13.0`) → pushes tagged image + `-dless` variant AND updates `latest` + `latest-dless`
+
+The `latest` tag **only advances on stable releases**. Pre-releases do not update it.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ docker buildx imagetools inspect ghcr.io/flare-foundation/go-flare:<TAG> \
 
 ### Verify GitHub artifact attestations
 
+Browse all attestations for this repository: <https://github.com/flare-foundation/go-flare/attestations>
+
 Requires [GitHub CLI](https://cli.github.com/) 2.49 or later:
 
 ```bash


### PR DESCRIPTION
# Description

- Update README with relevant information.
- Add SBOM generation and upload to attestations.
- Add provenance generation and uploading it to attestations.
- Adding so that the latest build tag will have "latest" attached to it ([example](https://github.com/lovc21/go-flare/pkgs/container/go-flare/816931556?tag=latest)), so it will be easier for clients to pull latest images.

# docs
https://docs.github.com/en/actions/concepts/security/artifact-attestations
https://docs.docker.com/build/ci/github-actions/attestations/